### PR TITLE
[Chore] Set absenceRegion/workspaceAbsences methods under the users page

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -103,6 +103,8 @@ navigation:
       - userCapacity
       - userTags
       - absences
+      - absenceRegions
+      - workspaceAbsences
       - dashboards
       - page: Files & Images Overview
         path: ./pages/api/files.mdx


### PR DESCRIPTION
As in title, moving the absenceRegion and workspaceAbsence methods under the users section

<img width="389" alt="image" src="https://github.com/user-attachments/assets/4b4071ab-ec91-4eb9-af18-4e07e5563410">
