### PR TITLE
[Feature] Add timeentries v2 docs and retainer projects details

### DIFF
--- a/fern/apis/v2/summary.mdx
+++ b/fern/apis/v2/summary.mdx
@@ -8,4 +8,6 @@ This API Reference lists all entities and operations supported by the awork API 
 
 ## API v2
 
-This is the second version of the awork API, which introduces some new endpoints that would otherwise be breaking changes. All other features and concepts of the v1 still apply.
+This is the second version of the awork API. All features and concepts of the v1 apply.
+The goal of the v2 is to provide new versions of existig endpoints which introduce mayor breaking changes. v1 and v2 are usually backwards compatible, so that entities created via v1 can be used in v2 and vice versa to give users time to migrate.
+New features will be added to the v1.

--- a/fern/pages/api/projects.mdx
+++ b/fern/pages/api/projects.mdx
@@ -35,6 +35,21 @@ curl -X POST "https://api.awork.com/api/v1/projects" \
          }'
 ```
 
+### Working with retainer projects
+
+Retainer projects are project which have at least one retainer budget. They have the `isRetainer` property set to `true`. The `timebudget` property of a retainer project cannot be updated manually but instead shows the sum of all timebudgets of all retainer budgets of the project.
+In order to turn a retainer project back to a normal project, all retainer budgets have to be deleted.
+
+### Calculated properties
+
+The following properties are calculated and cannot be set manually:
+- `trackedDuration` -> The sum of the `duration` of all time entries of the project. If the `deductNonBillableHours` property of the project is set to `false`, only time entries with `isBillable` set to `true` are included in the calculation.
+- `plannedDuration` -> The sum of plannedDuration of all tasks of the project.
+- `tasksCount` -> The number of tasks of the project.
+- `tasksDoneCount` -> The number of tasks of the project which are done.
+- Special case for `timebudget`: The `timebudget` property of a retainer project cannot be updated manually but instead shows the sum of all timebudgets of all retainer budgets of the project.
+
+
 ## Get more help
 
 Make sure to check out our dedicated support page on [getting started with projects](https://support.awork.com/en/articles/5336228-create-your-first-project) in awork.

--- a/fern/pages/api/projects.mdx
+++ b/fern/pages/api/projects.mdx
@@ -37,18 +37,18 @@ curl -X POST "https://api.awork.com/api/v1/projects" \
 
 ### Working with retainer projects
 
-Retainer projects are project which have at least one retainer budget. They have the `isRetainer` property set to `true`. The `timebudget` property of a retainer project cannot be updated manually but instead shows the sum of all timebudgets of all retainer budgets of the project.
-In order to turn a retainer project back to a normal project, all retainer budgets have to be deleted.
+Retainer projects are projects which have at least one retainer budget. They have the `isRetainer` property set to `true`. The `timebudget` property of a retainer project cannot be updated manually but instead shows the sum of all timebudgets of all retainer budgets of the project.
+In order to turn a retainer project back to a one-off budget, all retainer budgets have to be deleted.
 
 ### Calculated properties
 
 The following properties are calculated and cannot be set manually:
+
 - `trackedDuration` -> The sum of the `duration` of all time entries of the project. If the `deductNonBillableHours` property of the project is set to `false`, only time entries with `isBillable` set to `true` are included in the calculation.
 - `plannedDuration` -> The sum of plannedDuration of all tasks of the project.
 - `tasksCount` -> The number of tasks of the project.
 - `tasksDoneCount` -> The number of tasks of the project which are done.
 - Special case for `timebudget`: The `timebudget` property of a retainer project cannot be updated manually but instead shows the sum of all timebudgets of all retainer budgets of the project.
-
 
 ## Get more help
 

--- a/fern/pages/api/timetracking.mdx
+++ b/fern/pages/api/timetracking.mdx
@@ -6,6 +6,13 @@ slug: timetracking
 
 Time Tracking and the resulting Time Entries allow project progress to be tracked and ultimately billed to a client.
 
+<Callout type="warning">
+  There is a v2 version of the Time Tracking API available here: [Time Tracking
+  v2](timetrackingv2). Please migrate to the v2 version as soon as possible. The
+  v1 endpoints of the `/timetracking` and `/timeentries` endpoints will be
+  removed in the future.
+</Callout>
+
 ## How to work with time tracking
 
 Time Tracking in awork is based on Time Entries. Time Entries are created for a specific project and task and are always assigned to a user. There are two ways to create time entries: manually or using the timer.

--- a/fern/pages/api/v2/timetracking.mdx
+++ b/fern/pages/api/v2/timetracking.mdx
@@ -4,4 +4,89 @@ description: Time Tracking API Reference.
 slug: timetrackingv2
 ---
 
-Time Tracking v2
+This is the v2 version of the Time Entries API. Please make sure to use the v2 route as shown in the examples.
+
+## Changes to the v2 version
+
+The TimeEntry model has been changed to allow for more flexibility when working with dates and times. The following changes have been made:
+
+- The `startDate` and `endDate` fields now combine date and time components, no more StartDateUtc and StartTimeUtc. Both dates are stored in UTC. The timezone on the time entry is only used to display in which timezone the time entry was created. There are no more local date and time fields.
+- A new property `isDateOnly` has been added to the TimeEntry model to show whether the time entry is a date only entry or not as this cannot be done by not specifying the StartTimeUtc anymore. Date only time entries are required to have a duration > 0.
+
+## How to work with time tracking
+
+Time Tracking in awork is based on Time Entries. Time Entries are created for a specific project and task and are always assigned to a user. The only way a user of a time entry can be not set is if the user was deleted without his/her time entries. In this case the userId will be set to null.
+There are two ways to create time entries: manually or using the timer.
+
+### Creating a time entry manually
+
+There are multiple ways to create time entries. The easiest way is by specifying the `startDate` and `duration`. The only other required fields for creating a time entry are the `timezone`, `typeOfWorkId` and `userId`.
+
+```sh title="Request" {4-8}
+curl -X POST "https://api.awork.com/api/v2/timeentries" \
+     -H "Content-Type: application/json" \
+     -d '{
+            "timezone": "Europe/Berlin",
+            "userId": "123e4567-e89b-12d3-a456-426614174000",
+            "typeOfWorkId": "123e4567-e89b-12d3-a456-426614174000",
+            "startDate": "2024-05-14T10:00:00Z",
+            "duration": 3600
+         }'
+```
+
+Alternatively, you can also specify the `startDate` and `endDate` fields to create a time entry for a specific time range.
+If you specify both `duration`and `endDate`, the `endDate` takes precedence and will be used to calculate the `duration`.
+
+Additionally, you can assign the time entry to a specific project and task by providing the `projectId` and `taskId` fields.
+
+```sh title="Request" {7-8}
+curl -X POST "https://api.awork.com/api/v2/timeentries" \
+     -H "Content-Type: application/json" \
+     -d '{
+            "timezone": "Europe/Berlin",
+            "userId": "123e4567-e89b-12d3-a456-426614174000",
+            "typeOfWorkId": "123e4567-e89b-12d3-a456-426614174000",
+            "projectId": "123e4567-e89b-12d3-a456-426614174000",
+            "taskId": "123e4567-e89b-12d3-a456-426614174000",
+            "startDate": "2024-05-14T10:00:00Z",
+            "duration": 3600
+         }'
+```
+
+### Using the timer
+
+The timer is a convenient way to track time while working on a task or project. To start the timer, you need to make a request to `POST /v2/users/:userId/timetracking/start`.
+
+```sh title="Request"
+curl -X POST https://api.awork.com/api/v2/users/123e4567-e89b-12d3-a456-426614174000/timetracking/start \
+     -H "Content-Type: application/json" \
+     -d '{
+            "timezone": "Europe/Berlin",
+            "typeOfWorkId": "123e4567-e89b-12d3-a456-426614174000",
+         }'
+```
+
+To find the currently running time entry of a user, you can use the `GET /v2/users/:userId/timeentries/last` endpoint and check whether the returned time entry has a duration of 0, which indicates that the timer is running. If the duration is > 0, no timer is running.
+
+```sh title="Request"
+curl -X POST https://api.awork.com/api/v2/users/123e4567-e89b-12d3-a456-426614174000/timeentries/last
+```
+
+You can additionally specify the project and task to start the timer for. You can then also pause, resume and stop the timer. There can only be one active timer per user. Timers are automatically stopped after 24h or when the time entry reaches the maximum allowed time for that user and day.
+
+See the [Tracking Times](https://support.awork.com/en/articles/5366812-tracking-times) for more details on how the timer works.
+
+### Working with breaks
+
+When using the timer, the timer can also be paused. This will create a break entry for the time the timer was paused. When the timer is resumed, the `endDate` of the break entry will be set and the `breakDuration`on the time entry will be updated. The `breakDuration` is the sum of all break entries for the time entry. When a time entry has a `breakDuration`, the `breakDuration` will have an influence on the duration calculations:
+
+- If the `startDate` and `duration` are specified, the `endDate` will be calculated as `startDate + duration + breakDuration`
+- If the `startDate` and `endDate` are specified, the `duration` will be calculated as `endDate - startDate - breakDuration`
+
+Breaks cannot be created/updated/deleted manually. They are only created when the timer is paused and resumed.
+
+If you want to remove the breaks, you can do so by making a request to `POST /v2/timeentries/:timeEntryId/breaks/remove`.
+
+```sh title="Request"
+curl -X POST https://api.awork.com/api/v2/timeentries/123e4567-e89b-12d3-a456-426614174000/removeBreaks
+```

--- a/fern/pages/changelog.mdx
+++ b/fern/pages/changelog.mdx
@@ -20,6 +20,20 @@ This section shows upcoming changes.
 
 This section shows you recent changes that are already live in our API.
 
+### Updated: Time Tracking v2 🚨
+
+In order to improve the time tracking experience in awork, especially around date handling and timezones, we have released a new version of the time tracking API. The new version can be found here: [Time Tracking v2](timetrackingv2). Please migrate to the new endpoints as soon as possible, as the old endpoints will be removed in the future after a longer deprecation period.
+
+The main changes are:
+- The `startDate` and `endDate` fields now combine date and time components, removing the StartDateUtc and StartTimeUtc fields. There are no more local date and time fields, the `startDate` and `endDate` fields are always in UTC. The combination now allows filtering on the time component of the date as well which was previously not possible as we don't support filtering on TimeSpans in the API.
+- A new property `isDateOnly` has been added to the TimeEntry model to show whether the time entry is a date only entry or not as this cannot be done by not specifying the StartTimeUtc anymore. Date only time entries are required to have a duration > 0.
+
+### New: Retainer projects 🚀
+
+Retainer budgets have been a highly requested feature in awork that we are finally releasing. Retainer budgets help you manage recurring time budgets for projects. As part of the release, the Project model gets a new property `isRetainer` which is set to `true` if the project has at least one retainer budget. Managing retainers is currently only possible via the web app.
+
+<Note>The `timebudget` property of a retainer project cannot be updated manually but instead shows the sum of all timebudgets of all retainer budgets of the project.</Note>
+
 ### New: Custom Fields 🚀
 
 Custom fields is one of the most highly requested features in awork. They allow users to add custom properties to tasks via projects and project templates. Custom fields can be of different types, such as text, number, date, and more.


### PR DESCRIPTION
This PR adds to improvements to the docs:
- create Time Entries Overview V2 page (similar to v1 + changes overview and additional info on working with breaks
- update projects overview page to add info on working with retainer projects and calculated properties