### PR TITLE
[Chore] Remove v2 for now

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -164,17 +164,17 @@ navigation:
   # - page: Others
   #   path: ./pages/api/others.mdx
   #   icon: angles-right
-- api: API v2 Reference
-  api-name: v2
-  paginated: true
-  display-errors: true
-  summary: ./apis/v2/summary.mdx
-  slug: apiv2
-  layout:
-  - page: Time Tracking Overview
-    path: ./pages/api/v2/timetracking.mdx
-    icon: timer
-  - timeTracking
+# - api: API v2 Reference
+#   api-name: v2
+#   paginated: true
+#   display-errors: true
+#   summary: ./apis/v2/summary.mdx
+#   slug: apiv2
+#   layout:
+#   - page: Time Tracking Overview
+#     path: ./pages/api/v2/timetracking.mdx
+#     icon: timer
+#   - timeTracking
 
 navbar-links:
 - type: secondary

--- a/fern/pages/api/timetracking.mdx
+++ b/fern/pages/api/timetracking.mdx
@@ -6,13 +6,6 @@ slug: timetracking
 
 Time Tracking and the resulting Time Entries allow project progress to be tracked and ultimately billed to a client.
 
-<Callout type="warning">
-  There is a v2 version of the Time Tracking API available here: [Time Tracking
-  v2](timetrackingv2). Please migrate to the v2 version as soon as possible. The
-  v1 endpoints of the `/timetracking` and `/timeentries` endpoints will be
-  removed in the future.
-</Callout>
-
 ## How to work with time tracking
 
 Time Tracking in awork is based on Time Entries. Time Entries are created for a specific project and task and are always assigned to a user. There are two ways to create time entries: manually or using the timer.

--- a/fern/pages/changelog.mdx
+++ b/fern/pages/changelog.mdx
@@ -20,14 +20,6 @@ This section shows upcoming changes.
 
 This section shows you recent changes that are already live in our API.
 
-### Updated: Time Tracking v2 🚨
-
-In order to improve the time tracking experience in awork, especially around date handling and timezones, we have released a new version of the time tracking API. The new version can be found here: [Time Tracking v2](timetrackingv2). Please migrate to the new endpoints as soon as possible, as the old endpoints will be removed in the future after a longer deprecation period.
-
-The main changes are:
-- The `startDate` and `endDate` fields now combine date and time components, removing the StartDateUtc and StartTimeUtc fields. There are no more local date and time fields, the `startDate` and `endDate` fields are always in UTC. The combination now allows filtering on the time component of the date as well which was previously not possible as we don't support filtering on TimeSpans in the API.
-- A new property `isDateOnly` has been added to the TimeEntry model to show whether the time entry is a date only entry or not as this cannot be done by not specifying the StartTimeUtc anymore. Date only time entries are required to have a duration > 0.
-
 ### New: Retainer projects 🚀
 
 Retainer budgets have been a highly requested feature in awork that we are finally releasing. Retainer budgets help you manage recurring time budgets for projects. As part of the release, the Project model gets a new property `isRetainer` which is set to `true` if the project has at least one retainer budget. Managing retainers is currently only possible via the web app.

--- a/fern/pages/versioning.mdx
+++ b/fern/pages/versioning.mdx
@@ -13,11 +13,3 @@ The v1 API is the default version and uses the following URL pattern:
 ```
 https://api.awork.com/api/v1/{endpoint}
 ```
-
-### v2 (Selected Endpoints)
-Some endpoints offer a v2 version to introduce improvements without breaking changes:
-```
-https://api.awork.com/api/v2/{endpoint}
-```
-
-Note that v2 is not available for all endpoints. The v2 endpoints are specifically designed to provide enhanced functionality while maintaining backwards compatibility with their v1 counterparts. Please refer to the specific endpoint documentation to check if a v2 version is available.


### PR DESCRIPTION
Decided to remove v2 to fix the time tracking endpoints first.

https://awork-gmbh.slack.com/archives/C08HKBR2AEN