### PR TITLE
[Chore] Add retainer endpoints + clean-up

### DIFF
--- a/fern/apis/v1/openapi/openapi.json
+++ b/fern/apis/v1/openapi/openapi.json
@@ -1823,7 +1823,7 @@
           "CommentFiles"
         ],
         "summary": "Returns the content of the comment file with the specified id.",
-        "description": "Returns the content of the comment file. Uses the latest file version.\r\nIf the comment file is an image and the width and height are set,\r\nthe image will resized before it is returned.",
+        "description": "Returns the content of the comment file. Uses the latest file version.\r\nIf the comment file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
         "parameters": [
           {
             "name": "commentId",
@@ -1945,7 +1945,7 @@
         "tags": [
           "CommentFiles"
         ],
-        "summary": "Returns a url to share the file.",
+        "summary": "Returns an url to share the file.",
         "description": "Returns a url to share the file.",
         "parameters": [
           {
@@ -3513,7 +3513,7 @@
           "CompanyFiles"
         ],
         "summary": "Returns the content of the company file with the specified id.",
-        "description": "Returns the content of the company file. Uses the latest file version.\r\nIf the company file is an image and the width and height are set,\r\nthe image will resized before it is returned.",
+        "description": "Returns the content of the company file. Uses the latest file version.\r\nIf the company file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
         "parameters": [
           {
             "name": "companyId",
@@ -3635,7 +3635,7 @@
         "tags": [
           "CompanyFiles"
         ],
-        "summary": "Returns a url to share the file.",
+        "summary": "Returns an url to share the file.",
         "description": "Returns a url to share the file.",
         "parameters": [
           {
@@ -4363,6 +4363,757 @@
         "x-access": {
           "admin": "true",
           "project-manage-config": "write"
+        }
+      }
+    },
+    "/documents/{documentId}/externalfiles": {
+      "post": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Endpoint to batch create external files without uploading.",
+        "description": "Endpoint to create file infos with batch operation.\r\nCreated file infos don't have a version.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "List of file forms.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ExternalFileForm"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ExternalFileForm"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files": {
+      "delete": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Deletes the files of the specified document.",
+        "description": "Deletes the metadata and the different versions of the files.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Returns all files of the document with the specified id.",
+        "description": "Returns all file metadata of the document with the specified id.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "$ref": "#/components/parameters/pageSize"
+          },
+          {
+            "$ref": "#/components/parameters/orderby"
+          },
+          {
+            "$ref": "#/components/parameters/filterby"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileInfo"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Creates a new document file for the document with the specified id..",
+        "description": "Uploads a new document file for the document with the specified id.\r\nUse this to upload a file as a form value along with the basic file meta data.\r\nThe file size must not exceed 1GB.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "File"
+                ],
+                "type": "object",
+                "properties": {
+                  "File": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "File": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files/byuploadid": {
+      "post": {
+        "tags": [
+          "FileUpload"
+        ],
+        "summary": "Creates a file from an upload id.",
+        "description": "After a file has been uploaded to an upload URL generated from the  endpoint, this endpoint can be used to create a file document from the uploaded file by providing the upload id.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadByUploadIdForm"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files/byurl": {
+      "post": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Uploads a new file by providing an url.",
+        "description": "The file needs to be a public available url.\r\nThe file size must not exceed 100MB.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document the file is linked to.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The url, name and description of the file.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FilePostForm"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/FilePostForm"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files/{fileId}": {
+      "delete": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Deletes the document file with the specified id.",
+        "description": "Deletes the metadata and the different versions of the file.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Returns the file with the specified id of the document with the specified id.",
+        "description": "Returns the file metadata of the document with the specified id.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileInfo"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Updates the metadata of the document file with the specified id.",
+        "description": "Updates the metadata of the document file with the specified id.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The model to update the file with the specified id.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileInfoUpdateForm"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileInfoUpdateForm"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files/{fileId}/download": {
+      "get": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Returns the content of the document file with the specified id.",
+        "description": "Returns the content of the document file. Uses the latest file version.\r\nIf the document file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "width",
+            "in": "query",
+            "description": "Set width to resize.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "height",
+            "in": "query",
+            "description": "Set height to resize.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "crop",
+            "in": "query",
+            "description": "Whether to crop the image when resizing it.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files/{fileId}/shareurl": {
+      "get": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Returns an url to share the file.",
+        "description": "Returns a url to share the file.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files/{fileId}/versions": {
+      "get": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Returns all file versions of the specified document file.",
+        "description": "Returns all file versions of the specified document file.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "$ref": "#/components/parameters/pageSize"
+          },
+          {
+            "$ref": "#/components/parameters/orderby"
+          },
+          {
+            "$ref": "#/components/parameters/filterby"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FileVersion"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Uploads a new version of the document file with the specified id.",
+        "description": "Uploads a new version of an document file.\r\nUse this to upload a file as a form value along with the basic file meta data.\r\nThe file size must not exceed 1GB.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "required": [
+                  "File"
+                ],
+                "type": "object",
+                "properties": {
+                  "File": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              },
+              "encoding": {
+                "File": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileVersion"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request"
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files/{fileId}/versions/{versionId}": {
+      "get": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Returns the document file version with the specified id.",
+        "description": "Returns the document file version with the specified id.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "versionId",
+            "in": "path",
+            "description": "The id of the file version.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileVersion"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{documentId}/files/{fileId}/versions/{versionId}/download": {
+      "get": {
+        "tags": [
+          "DocumentFiles"
+        ],
+        "summary": "Returns the content of the document file version with the specified id.",
+        "description": "Returns the content of the document file version with the specified id.",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "The id of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "fileId",
+            "in": "path",
+            "description": "The id of the file.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "versionId",
+            "in": "path",
+            "description": "The id of the file version.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/File"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -10609,7 +11360,7 @@
           "ProjectFiles"
         ],
         "summary": "Returns the content of the project file with the specified id.",
-        "description": "Returns the content of the project file. Uses the latest file version.\r\nIf the project file is an image and the width and height are set,\r\nthe image will resized before it is returned.",
+        "description": "Returns the content of the project file. Uses the latest file version.\r\nIf the project file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
         "parameters": [
           {
             "name": "projectId",
@@ -10731,7 +11482,7 @@
         "tags": [
           "ProjectFiles"
         ],
-        "summary": "Returns a url to share the file.",
+        "summary": "Returns an url to share the file.",
         "description": "Returns a url to share the file.",
         "parameters": [
           {
@@ -11549,6 +12300,123 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        },
+        "security": [
+          {
+            "oauth2": [
+              "full_access"
+            ]
+          }
+        ],
+        "x-api-versions": [
+          "v1"
+        ],
+        "x-access": {
+          "any": "true"
+        }
+      }
+    },
+    "/projects/{projectId}/retainers": {
+      "get": {
+        "tags": [
+          "Retainers"
+        ],
+        "summary": "Endpoint to get all retainers for a project.",
+        "description": "The user must have the ProjectMasterData write permission for the project to access this endpoint.\r\n\r\n<Check title=\"Required Permissions\">Any authenticated user.</Check>",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The id of the project.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/page"
+          },
+          {
+            "$ref": "#/components/parameters/pageSize"
+          },
+          {
+            "$ref": "#/components/parameters/orderby"
+          },
+          {
+            "$ref": "#/components/parameters/filterby"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Retainer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth2": [
+              "full_access"
+            ]
+          }
+        ],
+        "x-api-versions": [
+          "v1"
+        ],
+        "x-access": {
+          "any": "true"
+        }
+      }
+    },
+    "/projects/{projectId}/retainers/{retainerId}": {
+      "get": {
+        "tags": [
+          "Retainers"
+        ],
+        "summary": "Endpoint to get a retainer for a project by id.",
+        "description": "The user must have the ProjectMasterData write permission for the project to access this endpoint.\r\n\r\n<Check title=\"Required Permissions\">Any authenticated user.</Check>",
+        "parameters": [
+          {
+            "name": "projectId",
+            "in": "path",
+            "description": "The id of the project.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "retainerId",
+            "in": "path",
+            "description": "The id of the retainer.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Retainer"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -15914,7 +16782,7 @@
           "ProjectTemplateFiles"
         ],
         "summary": "Returns the content of the projecttemplate file with the specified id.",
-        "description": "Returns the content of the projecttemplate file. Uses the latest file version.\r\nIf the projecttemplate file is an image and the width and height are set,\r\nthe image will resized before it is returned.",
+        "description": "Returns the content of the projecttemplate file. Uses the latest file version.\r\nIf the projecttemplate file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
         "parameters": [
           {
             "name": "projecttemplateId",
@@ -16036,7 +16904,7 @@
         "tags": [
           "ProjectTemplateFiles"
         ],
-        "summary": "Returns a url to share the file.",
+        "summary": "Returns an url to share the file.",
         "description": "Returns a url to share the file.",
         "parameters": [
           {
@@ -20001,6 +20869,18 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
           }
         },
         "security": [
@@ -20041,6 +20921,18 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
           }
         },
         "security": [
@@ -21889,7 +22781,7 @@
           "TaskFiles"
         ],
         "summary": "Returns the content of the task file with the specified id.",
-        "description": "Returns the content of the task file. Uses the latest file version.\r\nIf the task file is an image and the width and height are set,\r\nthe image will resized before it is returned.",
+        "description": "Returns the content of the task file. Uses the latest file version.\r\nIf the task file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
         "parameters": [
           {
             "name": "taskId",
@@ -22011,7 +22903,7 @@
         "tags": [
           "TaskFiles"
         ],
-        "summary": "Returns a url to share the file.",
+        "summary": "Returns an url to share the file.",
         "description": "Returns a url to share the file.",
         "parameters": [
           {
@@ -24001,7 +24893,7 @@
           "TaskTemplateFiles"
         ],
         "summary": "Returns the content of the tasktemplate file with the specified id.",
-        "description": "Returns the content of the tasktemplate file. Uses the latest file version.\r\nIf the tasktemplate file is an image and the width and height are set,\r\nthe image will resized before it is returned.",
+        "description": "Returns the content of the tasktemplate file. Uses the latest file version.\r\nIf the tasktemplate file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
         "parameters": [
           {
             "name": "tasktemplateId",
@@ -24123,7 +25015,7 @@
         "tags": [
           "TaskTemplateFiles"
         ],
-        "summary": "Returns a url to share the file.",
+        "summary": "Returns an url to share the file.",
         "description": "Returns a url to share the file.",
         "parameters": [
           {
@@ -26034,6 +26926,43 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TimeTracking"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth2": [
+              "full_access"
+            ]
+          }
+        ],
+        "x-api-versions": [
+          "v1"
+        ],
+        "x-access": {
+          "any": "true"
+        }
+      }
+    },
+    "/timereports": {
+      "get": {
+        "tags": [
+          "TimeReports"
+        ],
+        "summary": "Returns all time reports of a user.",
+        "description": "Returns time reports the user created as well as the shared time reports of\r\nother users.\r\n\r\n<Check title=\"Required Permissions\">Any authenticated user.</Check>",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TimeReport"
+                  }
                 }
               }
             }
@@ -28204,7 +29133,7 @@
           "UserFiles"
         ],
         "summary": "Returns the content of the user file with the specified id.",
-        "description": "Returns the content of the user file. Uses the latest file version.\r\nIf the user file is an image and the width and height are set,\r\nthe image will resized before it is returned.",
+        "description": "Returns the content of the user file. Uses the latest file version.\r\nIf the user file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
         "parameters": [
           {
             "name": "userId",
@@ -28326,7 +29255,7 @@
         "tags": [
           "UserFiles"
         ],
-        "summary": "Returns a url to share the file.",
+        "summary": "Returns an url to share the file.",
         "description": "Returns a url to share the file.",
         "parameters": [
           {
@@ -30808,7 +31737,7 @@
           "WorkspaceFiles"
         ],
         "summary": "Returns the content of the workspace file with the specified id.",
-        "description": "Returns the content of the workspace file. Uses the latest file version.\r\nIf the workspace file is an image and the width and height are set,\r\nthe image will resized before it is returned.",
+        "description": "Returns the content of the workspace file. Uses the latest file version.\r\nIf the workspace file is an image and the width and height are set,\r\nthe image will be resized before it is returned.",
         "parameters": [
           {
             "name": "workspaceId",
@@ -30930,7 +31859,7 @@
         "tags": [
           "WorkspaceFiles"
         ],
-        "summary": "Returns a url to share the file.",
+        "summary": "Returns an url to share the file.",
         "description": "Returns a url to share the file.",
         "parameters": [
           {
@@ -33482,6 +34411,7 @@
             "minLength": 1,
             "type": "string",
             "description": "The email of the new user.",
+            "format": "email",
             "example": "carla.creative@ncnstn.com"
           },
           "roleId": {
@@ -33503,9 +34433,13 @@
             "example": "Creative"
           },
           "gender": {
+            "enum": [
+              "male",
+              "female",
+              "other"
+            ],
             "type": "string",
             "description": "The gender of the user to be invited.\r\nCould be 'male', 'female', 'other'",
-            "nullable": true,
             "example": "female"
           }
         },
@@ -33548,6 +34482,37 @@
             "description": "The id of the region to assign the users to.",
             "format": "uuid",
             "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AutofixForm": {
+        "type": "object",
+        "properties": {
+          "operationId": {
+            "type": "string",
+            "description": "A unique id to track the AI operation, provided by the client.\r\nWill be returned in the websocket events related to this async process.",
+            "format": "uuid",
+            "nullable": true,
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "bookingIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The ids of the bookings to fix.",
+            "nullable": true
+          },
+          "taskIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The ids of the tasks to fix.",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -35106,6 +36071,95 @@
         "additionalProperties": false,
         "description": "The contact info are different types of contact information for a user."
       },
+      "ContributorForm": {
+        "required": [
+          "accessLevel"
+        ],
+        "type": "object",
+        "properties": {
+          "accessLevel": {
+            "minLength": 1,
+            "enum": [
+              "read",
+              "manage"
+            ],
+            "type": "string",
+            "description": "Determines the level of access granted to this contributor with respect to the referenced entity.\r\nCan be either set to `read` or `manage`."
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContributorModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The id of the contributor.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "userId": {
+            "type": "string",
+            "description": "The id of the user this contributor references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "description": "Determines the level of access granted to this contributor with respect to the specific entity.\r\nCan be either set to `read` or `manage`.",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The first name of the user.",
+            "nullable": true,
+            "example": "Lisa"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The last name of the user.",
+            "nullable": true,
+            "example": "Smith"
+          },
+          "hasImage": {
+            "type": "boolean",
+            "description": "Whether the user has an image.",
+            "nullable": true,
+            "example": true
+          },
+          "isDeactivated": {
+            "type": "boolean",
+            "description": "Whether the user is deactivated.",
+            "example": false
+          }
+        },
+        "additionalProperties": false
+      },
+      "ContributorPostForm": {
+        "required": [
+          "accessLevel",
+          "userId"
+        ],
+        "type": "object",
+        "properties": {
+          "accessLevel": {
+            "minLength": 1,
+            "enum": [
+              "read",
+              "manage"
+            ],
+            "type": "string",
+            "description": "Determines the level of access granted to this contributor with respect to the referenced entity.\r\nCan be either set to `read` or `manage`."
+          },
+          "userId": {
+            "type": "string",
+            "description": "The id of the user this contributor references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        },
+        "additionalProperties": false
+      },
       "CopyTaskBundleForm": {
         "type": "object",
         "properties": {
@@ -36049,6 +37103,68 @@
         },
         "additionalProperties": false
       },
+      "DocumentContributorModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The id of the contributor.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "userId": {
+            "type": "string",
+            "description": "The id of the user this contributor references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "description": "Determines the level of access granted to this contributor with respect to the specific entity.\r\nCan be either set to `read` or `manage`.",
+            "nullable": true
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The first name of the user.",
+            "nullable": true,
+            "example": "Lisa"
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The last name of the user.",
+            "nullable": true,
+            "example": "Smith"
+          },
+          "hasImage": {
+            "type": "boolean",
+            "description": "Whether the user has an image.",
+            "nullable": true,
+            "example": true
+          },
+          "isDeactivated": {
+            "type": "boolean",
+            "description": "Whether the user is deactivated.",
+            "example": false
+          },
+          "documentId": {
+            "type": "string",
+            "description": "The id of the referenced document.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "inheritedFromDocumentContributorId": {
+            "type": "string",
+            "description": "The id of the contributor the permission has been inherited from.",
+            "format": "uuid",
+            "nullable": true,
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "inheritedDocumentContributor": {
+            "$ref": "#/components/schemas/PermissionInheritedDocumentContributor"
+          }
+        },
+        "additionalProperties": false
+      },
       "DocumentForm": {
         "type": "object",
         "properties": {
@@ -36066,7 +37182,7 @@
             "nullable": true,
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
-          "documentParentId": {
+          "parentId": {
             "type": "string",
             "description": "The id of the document's parent document.",
             "format": "uuid",
@@ -36103,6 +37219,50 @@
             "description": "The order of the document in either the list of private docs,\r\nthe referenced document space or in the referenced project.",
             "format": "double",
             "nullable": true
+          },
+          "workspaceAccessLevel": {
+            "maxLength": 25,
+            "minLength": 0,
+            "enum": [
+              "none",
+              "read",
+              "manage"
+            ],
+            "type": "string",
+            "description": "Determines the level of access to this document granted to all workspace users.\r\nCan be either null (inherited), `none`, `read`, or `manage`.",
+            "nullable": true
+          },
+          "isHiddenForConnectUsers": {
+            "type": "boolean",
+            "description": "Whether the document is hidden for connect users.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DocumentMentionForm": {
+        "required": [
+          "positionEnd",
+          "positionStart",
+          "userId"
+        ],
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "The id of the user this mention references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "positionStart": {
+            "type": "integer",
+            "description": "The exact position of where in the document the user mention has started.",
+            "format": "int32"
+          },
+          "positionEnd": {
+            "type": "integer",
+            "description": "The exact position of where in the document the user mention has ended.",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -36112,7 +37272,24 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The id of the document.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "createdOn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "updatedOn": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedBy": {
+            "type": "string",
             "format": "uuid",
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
@@ -36125,6 +37302,7 @@
             "type": "string",
             "description": "The id of the current document version.",
             "format": "uuid",
+            "nullable": true,
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
           "documentSpaceId": {
@@ -36134,7 +37312,10 @@
             "nullable": true,
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
-          "documentParentId": {
+          "documentSpace": {
+            "$ref": "#/components/schemas/PermissionDocumentSpace"
+          },
+          "parentId": {
             "type": "string",
             "description": "The id of the document's parent document.",
             "format": "uuid",
@@ -36147,6 +37328,9 @@
             "format": "uuid",
             "nullable": true,
             "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "project": {
+            "$ref": "#/components/schemas/PermissionProject"
           },
           "taskId": {
             "type": "string",
@@ -36164,37 +37348,50 @@
             "type": "boolean",
             "description": "Whether the document is private."
           },
-          "isExternal": {
-            "type": "boolean",
-            "description": "Whether the document belongs to an external project."
-          },
           "order": {
             "type": "number",
             "description": "The order of the document in either the list of private docs,\r\nthe referenced document space or in the referenced project.",
             "format": "double",
             "nullable": true
           },
-          "createdOn": {
-            "type": "string",
-            "description": "The date this document was created.",
-            "format": "date-time"
+          "isExternal": {
+            "type": "boolean",
+            "description": "Whether the document belongs to an external project."
           },
-          "createdBy": {
+          "isHiddenForConnectUsers": {
+            "type": "boolean",
+            "description": "Whether the document is hidden for connect users."
+          },
+          "contributors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentContributorModel"
+            },
+            "description": "The contributors of this document.",
+            "nullable": true
+          },
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentToTeamModel"
+            },
+            "description": "The teams this document is connected to.",
+            "nullable": true
+          },
+          "workspaceAccessLevel": {
             "type": "string",
-            "description": "The id of the user who created this document.",
+            "description": "Determines the level of access to this document granted to all workspace users.\r\nCan be either not set (no access), `read`, or `manage`.",
+            "nullable": true
+          },
+          "inheritedWorkspaceAccessFromDocumentId": {
+            "type": "string",
+            "description": "The id of the document the workspace access level permission has been inherited from.",
             "format": "uuid",
+            "nullable": true,
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
-          "updatedOn": {
-            "type": "string",
-            "description": "The date this document was last modified.",
-            "format": "date-time"
-          },
-          "updatedBy": {
-            "type": "string",
-            "description": "The id of the user who last modified this document.",
-            "format": "uuid",
-            "example": "123e4567-e89b-12d3-a456-426614174000"
+          "inheritedWorkspaceAccessFromDocument": {
+            "$ref": "#/components/schemas/PermissionInheritedWorkspaceAccessFromDocument"
           }
         },
         "additionalProperties": false
@@ -36216,7 +37413,7 @@
             "nullable": true,
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
-          "documentParentId": {
+          "parentId": {
             "type": "string",
             "description": "The id of the document's parent document.",
             "format": "uuid",
@@ -36252,6 +37449,23 @@
             "type": "number",
             "description": "The order of the document in either the list of private docs,\r\nthe referenced document space or in the referenced project.",
             "format": "double",
+            "nullable": true
+          },
+          "workspaceAccessLevel": {
+            "maxLength": 25,
+            "minLength": 0,
+            "enum": [
+              "none",
+              "read",
+              "manage"
+            ],
+            "type": "string",
+            "description": "Determines the level of access to this document granted to all workspace users.\r\nCan be either null (inherited), `none`, `read`, or `manage`.",
+            "nullable": true
+          },
+          "isHiddenForConnectUsers": {
+            "type": "boolean",
+            "description": "Whether the document is hidden for connect users.",
             "nullable": true
           },
           "content": {
@@ -36305,6 +37519,18 @@
             "description": "The order of the document space in the list of document spaces.",
             "format": "double",
             "nullable": true
+          },
+          "workspaceAccessLevel": {
+            "maxLength": 25,
+            "minLength": 0,
+            "enum": [
+              "none",
+              "read",
+              "manage"
+            ],
+            "type": "string",
+            "description": "Determines the level of access to this document space granted to all workspace users.\r\nCan be either `none`, `read`, or `manage`.",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -36356,6 +37582,84 @@
             "description": "The order of the document space in the list of document spaces.",
             "format": "double",
             "nullable": true
+          },
+          "workspaceAccessLevel": {
+            "type": "string",
+            "description": "Determines the level of access to this document space granted to all workspace users.\r\nCan be either not set (no access), `read`, or `manage`.",
+            "nullable": true
+          },
+          "contributors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContributorModel"
+            },
+            "description": "The contributors of this document space.",
+            "nullable": true
+          },
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityToTeamModel"
+            },
+            "description": "The teams this document space is connected to.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DocumentToTeamModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The id of the entity to team.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "teamId": {
+            "type": "string",
+            "description": "The id of the team this entity to team references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "description": "Determines the level of access granted to this entity to team with respect to the specific entity.\r\nCan be either set to `read` or `manage`.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the team.",
+            "nullable": true,
+            "example": "Designers"
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon which is assigned to the team.",
+            "nullable": true,
+            "example": "paintbrush"
+          },
+          "color": {
+            "type": "string",
+            "description": "The color of the team.",
+            "nullable": true,
+            "example": "purple"
+          },
+          "documentId": {
+            "type": "string",
+            "description": "The id of the referenced document.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "inheritedFromDocumentToTeamId": {
+            "type": "string",
+            "description": "The id of the document to team the permission has been inherited from.",
+            "format": "uuid",
+            "nullable": true,
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "inheritedDocumentToTeam": {
+            "$ref": "#/components/schemas/PermissionInheritedDocumentToTeam"
           }
         },
         "additionalProperties": false
@@ -36381,6 +37685,90 @@
         },
         "additionalProperties": false,
         "description": "Model to capture the time tracking statistics for an entity.\r\nIncludes the total tracked duration, total billable duration and total billed duration.\r\nThe total non-billable duration can be calculated by subtracting the total billable duration from the total tracked duration.\r\nThe total non-billed duration can be calculated by subtracting the total billed duration from the total billable duration."
+      },
+      "EntityToTeamForm": {
+        "required": [
+          "accessLevel"
+        ],
+        "type": "object",
+        "properties": {
+          "accessLevel": {
+            "minLength": 1,
+            "enum": [
+              "read",
+              "manage"
+            ],
+            "type": "string",
+            "description": "Determines the level of access granted to this contributor with respect to the referenced entity.\r\nCan be either set to `read` or `manage`."
+          }
+        },
+        "additionalProperties": false
+      },
+      "EntityToTeamModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The id of the entity to team.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "teamId": {
+            "type": "string",
+            "description": "The id of the team this entity to team references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "description": "Determines the level of access granted to this entity to team with respect to the specific entity.\r\nCan be either set to `read` or `manage`.",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the team.",
+            "nullable": true,
+            "example": "Designers"
+          },
+          "icon": {
+            "type": "string",
+            "description": "The icon which is assigned to the team.",
+            "nullable": true,
+            "example": "paintbrush"
+          },
+          "color": {
+            "type": "string",
+            "description": "The color of the team.",
+            "nullable": true,
+            "example": "purple"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EntityToTeamPostForm": {
+        "required": [
+          "accessLevel",
+          "teamId"
+        ],
+        "type": "object",
+        "properties": {
+          "accessLevel": {
+            "minLength": 1,
+            "enum": [
+              "read",
+              "manage"
+            ],
+            "type": "string",
+            "description": "Determines the level of access granted to this contributor with respect to the referenced entity.\r\nCan be either set to `read` or `manage`."
+          },
+          "teamId": {
+            "type": "string",
+            "description": "The id of the team this entity to team references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        },
+        "additionalProperties": false
       },
       "ErrorResponse": {
         "required": [
@@ -36739,13 +38127,6 @@
             "description": "The expected planned workload of the task, in seconds.",
             "format": "int32",
             "example": 21600
-          },
-          "remainingDuration": {
-            "type": "integer",
-            "description": "The expected remaining duration from the original planned effort of the task, in seconds.\r\nNull if the user has no permissions to see time tracking information.",
-            "format": "int32",
-            "nullable": true,
-            "example": 10500
           }
         },
         "additionalProperties": false
@@ -36805,13 +38186,6 @@
             "description": "The expected planned workload of the task, in seconds.",
             "format": "int32",
             "example": 21600
-          },
-          "remainingDuration": {
-            "type": "integer",
-            "description": "The expected remaining duration from the original planned effort of the task, in seconds.\r\nNull if the user has no permissions to see time tracking information.",
-            "format": "int32",
-            "nullable": true,
-            "example": 10500
           },
           "typeOfWorkId": {
             "type": "string",
@@ -37210,7 +38584,23 @@
         },
         "additionalProperties": false
       },
-      "MinimalChecklistProjectWithTeams": {
+      "MinimalChecklistProjectMember": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MinimalChecklistProjectWithMembers": {
         "type": "object",
         "properties": {
           "id": {
@@ -37269,12 +38659,12 @@
           "projectStatus": {
             "$ref": "#/components/schemas/DefaultStatusModel"
           },
-          "teams": {
+          "members": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ProjectTeamModel"
+              "$ref": "#/components/schemas/MinimalChecklistProjectMember"
             },
-            "description": "The teams of the project.",
+            "description": "The members of the project.",
             "nullable": true
           }
         },
@@ -37296,6 +38686,52 @@
           "hasImage": {
             "type": "boolean",
             "description": "Whether the user has an image."
+          }
+        },
+        "additionalProperties": false
+      },
+      "MinimalContributorModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The id of the contributor.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "userId": {
+            "type": "string",
+            "description": "The id of the user this contributor references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "description": "Determines the level of access granted to this contributor with respect to the specific entity.\r\nCan be either set to `read` or `manage`.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MinimalEntityToTeamModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The id of the entity to team.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "teamId": {
+            "type": "string",
+            "description": "The id of the team this entity to team references.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "description": "Determines the level of access granted to this entity to team with respect to the specific entity.\r\nCan be either set to `read` or `manage`.",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -37966,6 +39402,65 @@
         },
         "additionalProperties": false
       },
+      "PermissionContributor": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermissionDocumentSpace": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "workspaceAccessLevel": {
+            "type": "string",
+            "nullable": true
+          },
+          "contributors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermissionContributor"
+            },
+            "nullable": true
+          },
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermissionEntityToTeam"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermissionEntityToTeam": {
+        "type": "object",
+        "properties": {
+          "teamId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "PermissionFullModel": {
         "type": "object",
         "properties": {
@@ -37985,6 +39480,46 @@
             "example": [
               "read"
             ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermissionInheritedDocumentContributor": {
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermissionInheritedDocumentToTeam": {
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "accessLevel": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermissionInheritedWorkspaceAccessFromDocument": {
+        "type": "object",
+        "properties": {
+          "workspaceAccessLevel": {
+            "type": "string",
+            "nullable": true
           }
         },
         "additionalProperties": false
@@ -38140,6 +39675,42 @@
         },
         "additionalProperties": false
       },
+      "PermissionProject": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "createdBy": {
+            "type": "string",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "teams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermissionTeam"
+            },
+            "nullable": true
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PermissionProjectMember"
+            },
+            "nullable": true
+          },
+          "isPrivate": {
+            "type": "boolean"
+          },
+          "isExternal": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
       "PermissionProjectMember": {
         "type": "object",
         "properties": {
@@ -38218,7 +39789,15 @@
       "PlannerAnalyzerOptionalParameters": {
         "type": "object",
         "properties": {
-          "teamIds": {
+          "userFilter": {
+            "type": "string",
+            "nullable": true
+          },
+          "projectFilter": {
+            "type": "string",
+            "nullable": true
+          },
+          "taskFilterIds": {
             "type": "array",
             "items": {
               "type": "string",
@@ -38226,13 +39805,8 @@
             },
             "nullable": true
           },
-          "taskViewIds": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "nullable": true
+          "calculateOverbookedPerDay": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -38328,7 +39902,7 @@
             "example": "123e4567-e89b-12d3-a456-426614174000"
           },
           "project": {
-            "$ref": "#/components/schemas/MinimalChecklistProjectWithTeams"
+            "$ref": "#/components/schemas/MinimalChecklistProjectWithMembers"
           },
           "taskViewId": {
             "type": "string",
@@ -38468,13 +40042,14 @@
             "description": "The number of days that we will consider (from today) for the planner analysis.\r\nAt least 1 day is required.",
             "format": "int32"
           },
-          "teamIds": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "(optional) Filter the analysis to only include tasks/projects from these teams.",
+          "projectFilter": {
+            "type": "string",
+            "description": "(optional) The query filter for the project. The checklist will take into account only results relevant to those projects.",
+            "nullable": true
+          },
+          "userFilter": {
+            "type": "string",
+            "description": "(optional) The query filter for the user. The checklist will take into account only results relevant to those users.",
             "nullable": true
           },
           "taskFilterIds": {
@@ -38484,6 +40059,11 @@
               "format": "uuid"
             },
             "description": "(optional) Create, for each task filter, a checklist item.",
+            "nullable": true
+          },
+          "calculateOverbookedPerDay": {
+            "type": "boolean",
+            "description": "(optional, default = true) Calculate the overbooked users per day (instead of time frame average).",
             "nullable": true
           }
         },
@@ -39049,7 +40629,6 @@
       },
       "ProjectMemberForm": {
         "required": [
-          "isResponsible",
           "projectRoleId",
           "userId"
         ],
@@ -39123,6 +40702,12 @@
         "additionalProperties": false
       },
       "ProjectMilestone": {
+        "required": [
+          "color",
+          "dueDate",
+          "name",
+          "projectId"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -39130,7 +40715,6 @@
             "minLength": 0,
             "type": "string",
             "description": "The name of the milestone.",
-            "nullable": true,
             "example": "Internal Review"
           },
           "color": {
@@ -39138,7 +40722,6 @@
             "minLength": 0,
             "type": "string",
             "description": "The color of the milestone.",
-            "nullable": true,
             "example": "green"
           },
           "dueDate": {
@@ -39187,6 +40770,12 @@
         "additionalProperties": false
       },
       "ProjectMilestonePostForm": {
+        "required": [
+          "color",
+          "dueDate",
+          "name",
+          "projectId"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -39194,7 +40783,6 @@
             "minLength": 0,
             "type": "string",
             "description": "The name of the milestone.",
-            "nullable": true,
             "example": "Internal Review"
           },
           "color": {
@@ -39202,7 +40790,6 @@
             "minLength": 0,
             "type": "string",
             "description": "The color of the milestone.",
-            "nullable": true,
             "example": "green"
           },
           "dueDate": {
@@ -39221,6 +40808,11 @@
         "additionalProperties": false
       },
       "ProjectMilestonePutForm": {
+        "required": [
+          "color",
+          "dueDate",
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -39228,7 +40820,6 @@
             "minLength": 0,
             "type": "string",
             "description": "The name of the milestone.",
-            "nullable": true,
             "example": "Internal Review"
           },
           "color": {
@@ -39236,7 +40827,6 @@
             "minLength": 0,
             "type": "string",
             "description": "The color of the milestone.",
-            "nullable": true,
             "example": "green"
           },
           "dueDate": {
@@ -40117,51 +41707,6 @@
         },
         "additionalProperties": false
       },
-      "ProjectTimeBookingsAutoFixForm": {
-        "type": "object",
-        "properties": {
-          "autofixId": {
-            "type": "string",
-            "description": "A unique id to track the autofix process, provided by the client.\r\nWill be returned in the websocket events related to this autofix process.",
-            "format": "uuid",
-            "nullable": true,
-            "example": "123e4567-e89b-12d3-a456-426614174000"
-          },
-          "bookingIds": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "The ids of the bookings to fix.",
-            "nullable": true
-          },
-          "taskIds": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "description": "The ids of the tasks to fix.",
-            "nullable": true
-          },
-          "prompt": {
-            "type": "string",
-            "description": "Additional prompt for the AI to consider when creating the project time bookings.",
-            "nullable": true
-          },
-          "mode": {
-            "enum": [
-              "quick",
-              "full"
-            ],
-            "type": "string",
-            "description": "Which mode to use for the auto fix.\r\nDefault is quick.\r\nquick: uses a single AI call to generate a quick fix.\r\nfull: uses an iterative approach to generate a fix, which is more accurate but slower.",
-            "nullable": true
-          }
-        },
-        "additionalProperties": false
-      },
       "ProjectType": {
         "type": "object",
         "properties": {
@@ -40226,6 +41771,9 @@
         "description": "The project type model."
       },
       "ProjectTypeForm": {
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -40233,11 +41781,10 @@
             "minLength": 0,
             "type": "string",
             "description": "The names of the project type.",
-            "nullable": true,
             "example": "Brand Strategy"
           },
           "description": {
-            "maxLength": 25000,
+            "maxLength": 1000,
             "minLength": 0,
             "type": "string",
             "description": "A short description of the project type.",
@@ -40891,6 +42438,42 @@
         },
         "additionalProperties": false
       },
+      "RefineForm": {
+        "type": "object",
+        "properties": {
+          "operationId": {
+            "type": "string",
+            "description": "A unique id to track the AI operation, provided by the client.\r\nWill be returned in the websocket events related to this async process.",
+            "format": "uuid",
+            "nullable": true,
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "bookingIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The ids of the bookings to fix.",
+            "nullable": true
+          },
+          "taskIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The ids of the tasks to fix.",
+            "nullable": true
+          },
+          "prompt": {
+            "type": "string",
+            "description": "User-provided prompt for the AI operation to modify the bookings and tasks.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "ReorderingResult": {
         "required": [
           "id"
@@ -40919,12 +42502,14 @@
           "timeBudget": {
             "type": "integer",
             "description": "The time budget per retainer period in seconds. The default budget amount for new budgets in this retainer.",
-            "format": "int32"
+            "format": "int32",
+            "example": 3600
           },
           "timezone": {
             "type": "string",
             "description": "The timezone for when new budgets are created.",
-            "nullable": true
+            "nullable": true,
+            "example": "Europe/Berlin"
           },
           "rollOverUnderspentBudget": {
             "type": "boolean",
@@ -40932,18 +42517,21 @@
           },
           "rollOverOverspentBudget": {
             "type": "boolean",
-            "description": "Whether overspent budgets should be rolled over to the next period."
+            "description": "Whether overspent budgets should be rolled over to the next period.",
+            "example": true
           },
           "startDate": {
             "type": "string",
             "description": "The start of the retainer contract.",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2025-04-01T00:00:00Z"
           },
           "endDate": {
             "type": "string",
             "description": "The end of the retainer contract until new budgets will be created. Optional.",
             "format": "date-time",
-            "nullable": true
+            "nullable": true,
+            "example": "2025-04-30T00:00:00Z"
           },
           "syncProjectDates": {
             "type": "boolean",
@@ -40958,7 +42546,8 @@
           "retainerPeriod": {
             "type": "string",
             "description": "The period for new budgets in this retainer.\r\nCurrently only 'monthly' is supported.",
-            "nullable": true
+            "nullable": true,
+            "example": "monthly"
           },
           "projectId": {
             "type": "string",
@@ -40981,7 +42570,8 @@
           "createdOn": {
             "type": "string",
             "description": "The date this retainer was created.",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2025-04-01T00:00:00Z"
           },
           "createdBy": {
             "type": "string",
@@ -40992,7 +42582,8 @@
           "updatedOn": {
             "type": "string",
             "description": "The date this retainer was last modified.",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2025-04-01T00:00:00Z"
           },
           "updatedBy": {
             "type": "string",
@@ -41015,22 +42606,26 @@
           "timeBudget": {
             "type": "integer",
             "description": "The budget for this retainer period in seconds.\r\nBased on the carry over option selected in the retainer settings, the timebudget is adjusted by the carry over from the previous period.",
-            "format": "int32"
+            "format": "int32",
+            "example": 3600
           },
           "trackedDuration": {
             "type": "integer",
             "description": "The sum of tracked time in this retainer period.\r\nContains billable and non-billable hours if the DeductNonBillableHours flag is set to true.\r\nContains only billable hours if the DeductNonBillableHours flag is set to false.\r\nTime entries belong to the retainer period if their StartDate is between the StartDate and EndDate of the retainer period.",
-            "format": "int32"
+            "format": "int32",
+            "example": 1800
           },
           "startDate": {
             "type": "string",
             "description": "The start of the retainer period in UTC.",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2025-04-01T00:00:00Z"
           },
           "endDate": {
             "type": "string",
             "description": "The end of the retainer period in UTC.",
-            "format": "date-time"
+            "format": "date-time",
+            "example": "2025-04-30T00:00:00Z"
           }
         },
         "additionalProperties": false
@@ -42224,13 +43819,6 @@
             "format": "int32",
             "example": 21600
           },
-          "remainingDuration": {
-            "type": "integer",
-            "description": "The expected remaining duration from the original planned effort of the task, in seconds.\r\nNull if the user has no permissions to see time tracking information.",
-            "format": "int32",
-            "nullable": true,
-            "example": 10500
-          },
           "id": {
             "type": "string",
             "description": "The Id of the task.",
@@ -42442,6 +44030,13 @@
             "format": "int32",
             "nullable": true,
             "example": 21600
+          },
+          "remainingDuration": {
+            "type": "integer",
+            "description": "The expected remaining duration from the original planned effort of the task, in seconds.\r\nNull if the user has no permissions to see time tracking information.",
+            "format": "int32",
+            "nullable": true,
+            "example": 10500
           },
           "totalRemainingDuration": {
             "type": "integer",
@@ -48044,6 +49639,10 @@
             "description": "Whether the web hook is currently active.",
             "example": true
           },
+          "onlyTriggerForMainEntityChanges": {
+            "type": "boolean",
+            "description": "Whether to only send events for main entity changes and not for nested entities if the webhook is for a model."
+          },
           "authenticationType": {
             "minLength": 1,
             "type": "string",
@@ -48138,6 +49737,10 @@
             "type": "boolean",
             "description": "Whether the web hook is currently active.",
             "example": true
+          },
+          "onlyTriggerForMainEntityChanges": {
+            "type": "boolean",
+            "description": "Whether to only send events for main entity changes and not for nested entities if the webhook is for a model."
           },
           "authenticationType": {
             "minLength": 1,
@@ -49698,6 +51301,62 @@
         "additionalProperties": false,
         "description": "The workspace setting model."
       },
+      "WorkspaceSimplified": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The id of the workspace.",
+            "format": "uuid",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "name": {
+            "type": "string",
+            "description": "The workspace name. Optional.",
+            "nullable": true,
+            "example": "NCNSTN Creative Agency"
+          },
+          "subdomains": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubdomainBase"
+            },
+            "description": "The workspace's subdomains.",
+            "nullable": true
+          },
+          "lastUsed": {
+            "type": "boolean",
+            "description": "Whether this is the workspace the current user last logged in with.",
+            "example": true
+          },
+          "isApproved": {
+            "type": "boolean",
+            "description": "Indicates if the user accepted the invitation to the workspace.",
+            "example": true
+          },
+          "hasImage": {
+            "type": "boolean",
+            "description": "Whether the workspace has uploaded a workspace image.",
+            "example": true
+          },
+          "updatedOn": {
+            "type": "string",
+            "description": "The date this workspace was last modified.",
+            "format": "date-time"
+          },
+          "isJoinable": {
+            "type": "boolean",
+            "description": "Whether this workspace has same domain sign up enabled and the account's email matches the permitted domains."
+          },
+          "isFull": {
+            "type": "boolean",
+            "description": "Whether this workspace is full and no more users can join. Used in same domain sign up flow.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "The simplified workspace GET model for cases where the user is not logged in."
+      },
       "WorkspaceWithSubscriptionDetails": {
         "type": "object",
         "properties": {
@@ -49970,6 +51629,10 @@
       "description": "The project types endpoints allow you to define different types for projects.\n                             The project types contain the basic information of the project.\n                             This includes the project roles, statuses and status orders."
     },
     {
+      "name": "Retainers",
+      "description": "Retainers are used for projects with recurring budgets. Currently only hourly based recurring budgets are supported."
+    },
+    {
       "name": "Roles",
       "description": "The roles endpoints allow you to configure the permissions of users.\n            You have the possibility to manage roles and assign users to these roles."
     },
@@ -50016,6 +51679,10 @@
     {
       "name": "TimeEntries",
       "description": "There are some endpoints which have a V2 version. For those the V1 endpoints will be deprecated in the future.\n                    Please use the V2 endpoints instead.\n                    The endpoints can be used for general operations on existing time entries.\n                    A time entry can be linked to a task and / or project, although it can also be created for the user themselves without any entity link.\n                    If the time entry is linked to a project it is also indirectly linked to the company of that project.\n                    Similarly, the time entry is automatically linked to the project of the the task."
+    },
+    {
+      "name": "TimeReports",
+      "description": "The endpoints to manage the time reports."
     },
     {
       "name": "TimeTracking",

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -69,6 +69,7 @@ navigation:
   - projectAutomations
   - projectActions
   - projectTimeBookings
+  - retainers
   - autopilot
   - page: Tasks Overview
     path: ./pages/api/tasks.mdx
@@ -92,9 +93,6 @@ navigation:
   - timeEntries
   - timeTracking
   - timeReports
-  - projectTimeEntries
-  - taskTimeEntries
-  - entityTimeEntries
   - page: Companies Overview
     path: ./pages/api/companies.mdx
     icon: crown

--- a/fern/pages/changelog.mdx
+++ b/fern/pages/changelog.mdx
@@ -22,7 +22,8 @@ This section shows you recent changes that are already live in our API.
 
 ### New: Retainer projects 🚀
 
-Retainer budgets have been a highly requested feature in awork that we are finally releasing. Retainer budgets help you manage recurring time budgets for projects. As part of the release, the Project model gets a new property `isRetainer` which is set to `true` if the project has at least one retainer budget. Managing retainers is currently only possible via the web app.
+Retainer budgets have been a highly requested feature in awork that we are finally releasing. Retainer budgets help you manage recurring time budgets for projects. As part of the release, the Project model gets a new property `isRetainer` which is set to `true` if the project has at least one retainer budget. You can retrieve the retainers of a project via the new `GET /projects/{projectId}/retainers` endpoint.
+Managing retainers is currently only possible via the web app.
 
 <Note>The `timebudget` property of a retainer project cannot be updated manually but instead shows the sum of all timebudgets of all retainer budgets of the project.</Note>
 


### PR DESCRIPTION
## Summary
This PR adds the GET retainer endpoints so external api users can view the different timebudgets.
- Update the openapi.json
- remove some entity time entry paths -> not there anymore as they were migrated to minimal api

## References
PR: https://github.com/awork-io/awork-backend/pull/5075