### PR TITLE
Create update-openapi.yaml GitHub workflow for nightly openapi spec updates

### DIFF
--- a/.github/workflows/update-openapi.yaml
+++ b/.github/workflows/update-openapi.yaml
@@ -1,0 +1,24 @@
+name: Update OpenAPI Specification
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-openapi:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update OpenAPI Spec
+        uses: fern-api/sync-openapi@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: 'update-openapi-spec'
+          update_from_source: true
+          add_timestamp: true


### PR DESCRIPTION
Use new `sync-openapi` action to pull OpenAPI specs from source (based on `generators.yml` config) every night
- see the README for more configuration options: https://github.com/fern-api/sync-openapi/blob/main/README.md
- ensure that GITHUB_TOKEN has the appropriate permissions (described in the like above) before merging