### PR TITLE
[Chore] Add user option to custom fields definition docs

### DIFF
--- a/fern/pages/api/customfields.mdx
+++ b/fern/pages/api/customfields.mdx
@@ -24,6 +24,7 @@ The following types are available for custom fields:
 | `coloredSelect` | A list of pre-defined selection options with colors. |
 | `link`          | A clickable URL input field.                         |
 | `boolean`       | A checkbox.                                          |
+| `user`          | A user selection.                                    |
 
 ## Creating a custom field
 


### PR DESCRIPTION
## Summary
Adds the user option to the custom fields definitions page.

See slack: https://awork-gmbh.slack.com/archives/C02U3FLM4KG/p1747819618094309