### PR TITLE
Add filtering apostrophe escaping instructions

### DIFF
--- a/fern/pages/filtering.mdx
+++ b/fern/pages/filtering.mdx
@@ -24,6 +24,11 @@ Incorrect:
 /companies?filterby=name eq 'awork & co'
 ```
 
+Use two single quotes to escape an apostrophe inside a string literal:
+```sh
+/tasks?filterby=name eq 'user''s task'
+```
+
 If you want to filter by a nested property, you can do this by separating the properties by `/`, for example:
 ```sh
 /projects?filterby=company/name eq 'awork'


### PR DESCRIPTION
Adds the detail on how to escape an apostrophe in the name by double quoting

<img width="847" height="825" alt="image" src="https://github.com/user-attachments/assets/e35dab12-2465-467c-87f3-4eb3dc377792" />
