### PR TITLE
[Chore] Add workflows documentation across API guides

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -156,10 +156,15 @@ navigation:
   - project templates
   - task bundles
   - task templates
+  - task template tags
   - task dependency templates
   - project template tags
   - project milestone templates
   - project template automations
+  - page: Workflows Overview
+    path: ./pages/api/workflows.mdx
+    icon: diagram-project
+  - workflows
   - page: Login & Access Overview
     path: ./pages/api/login.mdx
     icon: key

--- a/fern/pages/api/projects.mdx
+++ b/fern/pages/api/projects.mdx
@@ -22,6 +22,46 @@ curl -X POST "https://api.awork.com/api/v1/projects" \
          }'
 ```
 
+### Creating a project with a workflow
+
+You can create and link a project to a workflow directly in `POST /projects` by passing `workflowId`.
+If needed, you can also pass a valid `projectStatusId` from that workflow.
+
+```sh title="Request" {5-6}
+curl -X POST "https://api.awork.com/api/v1/projects" \
+     -H "Content-Type: application/json" \
+     -d '{
+           "name": "My workflow-based project",
+           "workflowId": "223e4567-e89b-12d3-a456-426614174000",
+           "projectStatusId": "323e4567-e89b-12d3-a456-426614174000"
+         }'
+```
+
+### Getting valid statuses for workflow-based project creation
+
+Before creating a project with `workflowId`, fetch the workflow statuses and pick a valid `projectStatusId`.
+
+```sh title="Get workflow project statuses"
+curl -X GET "https://api.awork.com/api/v1/workflows/223e4567-e89b-12d3-a456-426614174000/projectstatuses"
+```
+
+```sh title="Get workflow task statuses"
+curl -X GET "https://api.awork.com/api/v1/workflows/223e4567-e89b-12d3-a456-426614174000/taskstatuses"
+```
+
+### Getting valid statuses for an existing project
+
+Use project-scoped endpoints to fetch the statuses that are valid for one specific project.
+These endpoints already return the correct set, including workflow-inherited statuses when the project is linked to a workflow.
+
+```sh title="Get valid project statuses for a project"
+curl -X GET "https://api.awork.com/api/v1/projects/123e4567-e89b-12d3-a456-426614174000/projectstatuses"
+```
+
+```sh title="Get valid task statuses for a project"
+curl -X GET "https://api.awork.com/api/v1/projects/123e4567-e89b-12d3-a456-426614174000/taskstatuses"
+```
+
 ### Creating a project from a template
 
 To create a project from a project template, the `projectTemplateId` has to be passed in the `POST /projects` request.

--- a/fern/pages/api/projecttemplates.mdx
+++ b/fern/pages/api/projecttemplates.mdx
@@ -6,6 +6,55 @@ slug: projecttemplates
 
 Learn more about [project templates](https://support.awork.com/en/articles/5419200-project-templates).
 
+## Workflows and project templates
+
+Project templates can be connected to workflows so new projects created from that template use shared workflow statuses.
+
+The flow is:
+1. Create the project template.
+2. Link the template to a workflow.
+
+### Creating a project template
+
+```sh title="Create a project template" {4}
+curl -X POST https://api.awork.com/api/v1/projecttemplates \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Client Delivery Template"
+  }'
+```
+
+### Linking a project template to a workflow
+
+```sh title="Link template to workflow" {4}
+curl -X POST https://api.awork.com/api/v1/projecttemplates/123e4567-e89b-12d3-a456-426614174000/linkworkflow \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "workflowId": "223e4567-e89b-12d3-a456-426614174000",
+    "projectStatusMapping": [
+      {
+        "oldProjectStatusId": "323e4567-e89b-12d3-a456-426614174000",
+        "newProjectStatusId": "423e4567-e89b-12d3-a456-426614174000"
+      }
+    ],
+    "taskStatusMapping": [
+      {
+        "oldTaskStatusId": "523e4567-e89b-12d3-a456-426614174000",
+        "newTaskStatusId": "623e4567-e89b-12d3-a456-426614174000"
+      }
+    ],
+    "keepCustomFields": true,
+    "keepCustomAutomations": true
+  }'
+```
+
+### Unlinking a project template from a workflow
+
+```sh title="Unlink template from workflow"
+curl -X POST https://api.awork.com/api/v1/projecttemplates/123e4567-e89b-12d3-a456-426614174000/unlinkworkflow \
+  -H 'Content-Type: application/json'
+```
+
 ## Task Bundles
 
 **Task Bundles** (called "Task Templates" in the awork UI) are reusable containers that hold templates for tasks and task lists. They simplify recurring processes by allowing you to import a complete set of tasks and lists into projects.

--- a/fern/pages/api/workflows.mdx
+++ b/fern/pages/api/workflows.mdx
@@ -1,0 +1,99 @@
+---
+title: Workflows
+description: Workflows API Reference.
+slug: workflows
+---
+
+Workflows are reusable process definitions that let you share project statuses and task statuses across multiple projects. Instead of maintaining statuses per project, you can manage them once in a workflow and keep linked projects aligned.
+
+## How to work with workflows
+
+### Create a workflow
+
+Create a reusable workflow in your workspace.
+
+```sh title="Create a workflow"
+curl -X POST https://api.awork.com/api/v1/workflows \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Client Delivery Workflow",
+    "icon": "workflow"
+  }'
+```
+
+### Link a workflow to a project
+
+Linking applies workflow-controlled statuses to the project. If the project already has statuses, provide mappings to migrate safely.
+
+```sh title="Link workflow to a project" {4}
+curl -X POST https://api.awork.com/api/v1/projects/123e4567-e89b-12d3-a456-426614174000/linkworkflow \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "workflowId": "223e4567-e89b-12d3-a456-426614174000",
+    "projectStatusMapping": [
+      {
+        "oldProjectStatusId": "323e4567-e89b-12d3-a456-426614174000",
+        "newProjectStatusId": "423e4567-e89b-12d3-a456-426614174000"
+      }
+    ],
+    "taskStatusMapping": [
+      {
+        "oldTaskStatusId": "523e4567-e89b-12d3-a456-426614174000",
+        "newTaskStatusId": "623e4567-e89b-12d3-a456-426614174000"
+      }
+    ],
+    "keepCustomFields": true,
+    "keepCustomAutomations": true
+  }'
+```
+
+### Create a workflow from an existing project
+
+Use an existing project as a blueprint and optionally link that project to the newly created workflow.
+
+```sh title="Create workflow from project configuration"
+curl -X POST https://api.awork.com/api/v1/workflows/fromproject/123e4567-e89b-12d3-a456-426614174000 \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Workflow from Consulting Template",
+    "copyProjectStatuses": true,
+    "copyTaskStatuses": true,
+    "copyCustomFields": true,
+    "copyAutomations": true,
+    "linkProjectToWorkflow": true
+  }'
+```
+
+### Manage shared statuses in a workflow
+
+You can manage workflow-level statuses, which are then shared across linked projects.
+
+```sh title="Create task status in a workflow"
+curl -X POST https://api.awork.com/api/v1/workflows/223e4567-e89b-12d3-a456-426614174000/taskstatuses \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Client Feedback",
+    "type": "review",
+    "order": 3,
+    "icon": "comment"
+  }'
+```
+
+```sh title="Create project status in a workflow"
+curl -X POST https://api.awork.com/api/v1/workflows/223e4567-e89b-12d3-a456-426614174000/projectstatuses \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "name": "Blocked by Client",
+    "type": "stuck"
+  }'
+```
+
+### Unlink a workflow from a project
+
+Unlinking decouples the project from workflow sync and clones workflow statuses into editable project-specific statuses.
+
+```sh title="Unlink workflow from project"
+curl -X POST https://api.awork.com/api/v1/projects/123e4567-e89b-12d3-a456-426614174000/unlinkworkflow \
+  -H 'Content-Type: application/json'
+```
+

--- a/fern/pages/api/workflows.mdx
+++ b/fern/pages/api/workflows.mdx
@@ -6,6 +6,10 @@ slug: workflows
 
 Workflows are reusable process definitions that let you share project statuses and task statuses across multiple projects. Instead of maintaining statuses per project, you can manage them once in a workflow and keep linked projects aligned.
 
+<Note>
+  Workflows are being rolled out gradually across workspaces and might not be available in every workspace yet.
+</Note>
+
 ## How to work with workflows
 
 ### Create a workflow
@@ -96,4 +100,3 @@ Unlinking decouples the project from workflow sync and clones workflow statuses 
 curl -X POST https://api.awork.com/api/v1/projects/123e4567-e89b-12d3-a456-426614174000/unlinkworkflow \
   -H 'Content-Type: application/json'
 ```
-

--- a/fern/pages/changelog.mdx
+++ b/fern/pages/changelog.mdx
@@ -75,12 +75,9 @@ Task status example with Workflows:
 
 ### Migration path
 
-<CardGroup cols={2}>
+<CardGroup cols={1}>
   <Card title="Recommended path" icon="circle-check">
     Use project or project-template scoped endpoints to fetch statuses.
-  </Card>
-  <Card title="Alternative path" icon="code-branch">
-    Keep using global endpoint and filter by `workflowId` or `projectId`.
   </Card>
 </CardGroup>
 
@@ -144,65 +141,6 @@ curl -X GET "https://api.awork.com/api/v1/projecttemplates/3e664818-9503-4ec8-9f
 <Info>
   Project and task statuses can either have the `projectId` or `workflowId` set, depending on whether they are project or workflow specific. Project template statuses can either have the `projectTemplateId` or `workflowId` set, depending on whether they are template-specific or inherited from a workflow.
 </Info>
-
-#### Alternative migration path
-
-<Warning title="Not recommended">
-  Keep using global endpoint and filter by `workflowId` or `projectId`.
-</Warning>
-
-If you need to keep using the global endpoint, for example due to a high amount of projects:
-- Fetch the project statuses as before.
-- Fetch the project first and check `workflowId`.
-- If `workflowId` is set, filter statuses by `workflowId`.
-- If `workflowId` is null, filter statuses by `projectId`.
-
-<Info>
-  Projects with and without workflows can exist in the same workspace. This means that `GET /projectstatuses` will return project-scoped statuses as well as workflow-scoped statuses in one list.
-</Info>
-
-```sh title="1) Fetch all project statuses (as before)"
-curl -X GET "https://api.awork.com/api/v1/projectstatuses" \
-  -H "Authorization: Bearer {token}"
-```
-
-```json title="Project statuses response example"
-[
-  {
-    "id": "8b10f329-4cf3-42a5-a216-4560e318db8f",
-    "name": "In Progress",
-    "projectId": "3e664818-9503-4ec8-9f1f-35d5ad7a57ad",
-    "workflowId": null
-  },
-  {
-    "id": "0f5f3318-8024-4b0b-a748-7e8ed6f13a60",
-    "name": "In Progress",
-    "projectId": null,
-    "workflowId": "49f36ad2-9372-4ce2-a697-9ece6126d5cf"
-  }
-]
-```
-
-```sh title="2) Fetch project and check whether the project uses a workflow"
-curl -X GET "https://api.awork.com/api/v1/projects/3e664818-9503-4ec8-9f1f-35d5ad7a57ad" \
-  -H "Authorization: Bearer {token}"
-```
-
-```json title="Project with a workflow"
-{
-  "id": "3e664818-9503-4ec8-9f1f-35d5ad7a57ad",
-  "workflowId": "49f36ad2-9372-4ce2-a697-9ece6126d5cf"
-}
-```
-
-```json title="Project without a workflow"
-{
-  "id": "3e664818-9503-4ec8-9f1f-35d5ad7a57ad",
-  "workflowId": null
-}
-```
-
-3) If the project has a `workflowId` set, filter the global list of project statuses you retrieved earlier by this `workflowId`. If it does not have a workflow set, use the `projectId` as before.
 
 
 ### Questions and support


### PR DESCRIPTION
This PR adds a new Workflows overview section and page to the API v1 docs navigation. It documents workflow creation, linking/unlinking, create-from-project, and workflow-level status management with curl examples based on current workflow models. It expands the Projects guide with workflow-based project creation plus project-scoped status retrieval guidance, and updates the Project Templates guide with create-then-link workflow flows. It also removes the old changelog migration path that showed the global project statuses endpoint, keeping only project/project-template scoped guidance. All docs checks pass via fern check.