### PR TITLE
Upgrade Fern CLI to 5.5.1

### DIFF
--- a/fern/apis/v1/generators.yml
+++ b/fern/apis/v1/generators.yml
@@ -1,4 +1,14 @@
 api:
   specs:
-  - openapi: openapi/openapi.json
-    origin: https://app.awork.com/openapi/v1
+    - openapi: openapi/openapi.json
+      origin: https://app.awork.com/openapi/v1
+      settings:
+        title-as-schema-name: true
+        type-dates-as-strings: true
+        object-query-parameters: false
+        idiomatic-request-names: false
+        respect-nullable-schemas: false
+        wrap-references-to-nullable-in-optional: true
+        coerce-optional-schemas-to-nullable: true
+        inline-path-parameters: false
+        coerce-enums-to-literals: true

--- a/fern/apis/v2/generators.yml
+++ b/fern/apis/v2/generators.yml
@@ -1,4 +1,14 @@
 api:
   specs:
-  - openapi: openapi/openapi.json
-    origin: https://app.awork.com/openapi/v2
+    - openapi: openapi/openapi.json
+      origin: https://app.awork.com/openapi/v2
+      settings:
+        title-as-schema-name: true
+        type-dates-as-strings: true
+        object-query-parameters: false
+        idiomatic-request-names: false
+        respect-nullable-schemas: false
+        wrap-references-to-nullable-in-optional: true
+        coerce-optional-schemas-to-nullable: true
+        inline-path-parameters: false
+        coerce-enums-to-literals: true

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "awork",
-  "version": "0.121.0"
+  "version": "5.5.1"
 }


### PR DESCRIPTION
This PR upgrades Fern CLI from 0.121.0 to 5.5.1 in fern/fern.config.json. It also adds explicit OpenAPI spec settings to both v1 and v2 generator configs to preserve prior behavior after CLI migrations. These settings include schema naming, date typing, nullable/optional coercion, path parameter inlining, and enum coercion defaults. No OpenAPI spec files were edited.