### PR TITLE
Fix API reference navigation

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -133,7 +133,6 @@ navigation:
   - project files
   - task files
   - company files
-  - comment files
   - document files
   - user files
   - workspace files
@@ -165,6 +164,7 @@ navigation:
     path: ./pages/api/workflows.mdx
     icon: diagram-project
   - workflows
+  - workflow automations
   - page: Login & Access Overview
     path: ./pages/api/login.mdx
     icon: key


### PR DESCRIPTION
## Summary
- remove the obsolete `comment files` reference entry
- add the `workflow automations` reference entry under Workflows

## Validation
- `fern check`
- `fern check --warnings` (passes with one auth-related warning: missing redirects check skipped because Fern is not authenticated)