### PR TITLE
Migrate support URLs to HappySupport

### DIFF
--- a/fern/pages/api/customfields.mdx
+++ b/fern/pages/api/customfields.mdx
@@ -96,4 +96,4 @@ curl -X GET https://api.awork.com/api/v1/tasks/123e4567-e89b-12d3-a456-426614174
 }
 ```
 
-Learn more about [custom fields](https://support.awork.com/en/articles/9738993-custom-fields).
+Learn more about [custom fields](https://support.awork.com/en/articles/custom-fields-53uRWZpHr541).

--- a/fern/pages/api/files.mdx
+++ b/fern/pages/api/files.mdx
@@ -54,4 +54,4 @@ curl -X POST https://api.awork.com/api/v1/files/images/projects/123e4567-e89b-12
   -F 'File=@/path/to/file.png'
 ```
 
-See more on working with files and images in the [Help Center](https://support.awork.com/en/articles/5353332-project-files).
+See more on working with files and images in the [Help Center](https://support.awork.com/en/articles/files-in-projects-M9elACnwiurN).

--- a/fern/pages/api/login.mdx
+++ b/fern/pages/api/login.mdx
@@ -4,4 +4,4 @@ description: Login & Access API Reference.
 slug: login
 ---
 
-Learn more about awork's [permission management](https://support.awork.com/en/articles/5382825-permission-management).
+Learn more about awork's [permission management](https://support.awork.com/en/articles/permissions-management-in-awork-qVeVCScCl9db).

--- a/fern/pages/api/projects.mdx
+++ b/fern/pages/api/projects.mdx
@@ -134,4 +134,4 @@ You can use:
 
 ## Get more help
 
-Make sure to check out our dedicated support page on [getting started with projects](https://support.awork.com/en/articles/5336228-create-your-first-project) in awork.
+Make sure to check out our dedicated support page on [getting started with projects](https://support.awork.com/en/articles/creating-a-new-project-JNKI2Fpdql6g) in awork.

--- a/fern/pages/api/projecttemplates.mdx
+++ b/fern/pages/api/projecttemplates.mdx
@@ -4,7 +4,7 @@ description: Project Templates API Reference.
 slug: projecttemplates
 ---
 
-Learn more about [project templates](https://support.awork.com/en/articles/5419200-project-templates).
+Learn more about [project templates](https://support.awork.com/en/articles/project-templates-DhvJCSuVBExv).
 
 ## Workflows and project templates
 

--- a/fern/pages/api/search.mdx
+++ b/fern/pages/api/search.mdx
@@ -6,4 +6,4 @@ slug: search
 
 The search endpoint allows you to find entities by text in awork.
 
-[Learn more](https://support.awork.com/en/articles/5335267-search-and-find-in-awork) about how to search for your data in awork.
+[Learn more](https://support.awork.com/en/articles/the-main-menu-tEMWckKpWoHa) about how to search for your data in awork.

--- a/fern/pages/api/tasks.mdx
+++ b/fern/pages/api/tasks.mdx
@@ -54,7 +54,7 @@ curl -X POST https://api.awork.com/api/v1/tasks \
 
 <Note>The subtask has to be in the same project as the parent task.</Note>
 
-Learn more about subtasks [here](https://support.awork.com/en/articles/7050932-subtasks).
+Learn more about subtasks [here](https://support.awork.com/en/articles/subtasks-in-awork-fGEWc9HUZzuH).
 
 ## Checklist Items
 
@@ -68,7 +68,7 @@ curl -X POST https://api.awork.com/api/v1/tasks/123e4567-e89b-12d3-a456-42661417
   }'
 ```
 
-Learn more about checklists [here](https://support.awork.com/en/articles/5344365-editing-task-details#h_395962a83e).
+Learn more about checklists [here](https://support.awork.com/en/articles/all-task-details-v4YYVPSheclF).
 
 ## Task Lists
 

--- a/fern/pages/api/timetracking.mdx
+++ b/fern/pages/api/timetracking.mdx
@@ -59,4 +59,4 @@ curl -X POST https://api.awork.com/api/v1/users/123e4567-e89b-12d3-a456-42661417
 
 You can additionally specify the project and task to start the timer for. You can then also pause, resume and stop the timer. There can only be one active timer per user. Timers are automatically stopped after 24h or when the time entry reaches the maximum allowed time for that user and day.
 
-See the [Tracking Times](https://support.awork.com/en/articles/5366812-tracking-times) for more details on how the timer works.
+See the [Tracking Times](https://support.awork.com/en/articles/tracking-time-raMw6GG0xOry) for more details on how the timer works.

--- a/fern/pages/api/v2/timetracking.mdx
+++ b/fern/pages/api/v2/timetracking.mdx
@@ -74,7 +74,7 @@ curl -X GET https://api.awork.com/api/v2/users/123e4567-e89b-12d3-a456-426614174
 
 You can additionally specify the project and task to start the timer for. You can then also pause, resume and stop the timer. There can only be one active timer per user. Timers are automatically stopped after 24h or when the time entry reaches the maximum allowed time for that user and day.
 
-See the [Tracking Times](https://support.awork.com/en/articles/5366812-tracking-times) for more details on how the timer works.
+See the [Tracking Times](https://support.awork.com/en/articles/tracking-time-raMw6GG0xOry) for more details on how the timer works.
 
 ### Working with breaks
 

--- a/fern/pages/api/workload.mdx
+++ b/fern/pages/api/workload.mdx
@@ -4,4 +4,4 @@ description: Workload & Planning API Reference.
 slug: workload
 ---
 
-Learn more about [workload & planning](https://support.awork.com/en/articles/6131260-the-planner-timeline-calendar).
+Learn more about [workload & planning](https://support.awork.com/en/articles/the-planner-x2LDBA9A1rIq).

--- a/fern/pages/changelog.mdx
+++ b/fern/pages/changelog.mdx
@@ -32,7 +32,7 @@ Rollout note:
 - For workspaces with known ERP or custom integrations, the Workflows feature can remain deactivated until **July 31, 2026** at the latest.
 - Integrations should be upgraded before **July 31, 2026** to avoid issues when Workflows are enabled.
 - Workflows can be enabled earlier on request once the integration is ready.
-- [Please let us know](https://support.awork.com/en/articles/8778139-contact-support) once your integration has been updated or verified to be compatible, so we can enable Workflows for workspaces using that integration.
+- [Please let us know](https://support.awork.com/en/articles/getting-help-WS8JSOzZrf8a) once your integration has been updated or verified to be compatible, so we can enable Workflows for workspaces using that integration.
 
 Why this is breaking:
 - Previously, integrations often filtered status lists by `projectId`.

--- a/fern/pages/webhooks.mdx
+++ b/fern/pages/webhooks.mdx
@@ -62,7 +62,7 @@ Finally, select the events you want this webhook to trigger on. The following ev
 
 You can now trigger a test event to your configured URL.
 
-For more details, please take a look at our [Help Center](https://support.awork.com/en/articles/5415462-webhooks).
+For more details, please take a look at our [Help Center](https://support.awork.com/en/articles/webhooks-CqjKq3O26bV4).
 
 ## Receiving a Webhook
 
@@ -178,7 +178,7 @@ Should a configured webhook integration fail for more than 10 times without a su
 
 # Project Automation Webhooks
 
-Project automation webhooks can be configured as actions for project automations. Read more about project automations in our [Help Center](https://support.awork.com/en/articles/5354365-automations-in-projects#h_16583a3418).
+Project automation webhooks can be configured as actions for project automations. Read more about project automations in our [Help Center](https://support.awork.com/en/articles/automations-in-projects-8Y349YeytvNV).
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- replace legacy Intercom article URLs with their HappySupport slug-based equivalents
- keep the public `support.awork.com` domain for all migrated links
- remove obsolete Intercom heading anchors
- preserve the unmatched legacy `awork-switches-to-com` link because the English export contains no corresponding article

## Validation

- verified every replacement path against the supplied English HappySupport export
- confirmed 13 unique article URLs match the export
- `git diff --check`